### PR TITLE
Adding instructions for installing Pixlet on Arch Linux using the AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ brew install tidbyt/tidbyt/pixlet
 
 Download the `pixlet` binary from [the latest release][1].
 
+Arch Linux users can install the latest pixlet binary from the [Arch User Repository (AUR)](https://aur.archlinux.org/packages/pixlet-bin) using [yay](https://github.com/Jguer/yay):
+```
+yay -S pixlet-bin
+```
+
 Alternatively you can [build from source](docs/BUILD.md).
 
 [1]: https://github.com/tidbyt/pixlet/releases/latest


### PR DESCRIPTION
Greetings tidbyt team! I recently added a package to the popular Arch Linux Repository for the pixlet binary: https://aur.archlinux.org/packages/pixlet-bin. -- it downloads and installs the latest release binary from GitHub automatically.

I've updated the README of this repo to include instructions.

Please feel free to merge or reject at your discretion!